### PR TITLE
Vulkan 커맨드 병렬 기록

### DIFF
--- a/include/Core/ThreadPool.h
+++ b/include/Core/ThreadPool.h
@@ -49,5 +49,8 @@ namespace sh::core
 
 			return result;
 		}
+
+		SH_CORE_API auto GetThreads() const -> const std::vector<std::thread>&;
+		SH_CORE_API auto GetThreadNum() const -> uint32_t;
 	};
 }//namespace

--- a/include/Render/IVertexBuffer.h
+++ b/include/Render/IVertexBuffer.h
@@ -18,7 +18,5 @@ namespace sh::render
 
 		SH_RENDER_API virtual void Create(const Mesh& mesh) = 0;
 		SH_RENDER_API virtual void Clean() = 0;
-
-		SH_RENDER_API virtual void Bind() = 0;
 	};
 }

--- a/include/Render/RenderPipeline.h
+++ b/include/Render/RenderPipeline.h
@@ -71,5 +71,7 @@ namespace sh::render
 
 		SH_RENDER_API auto GetDrawCallCount() const -> uint32_t;
 		SH_RENDER_API auto GetPassName() const -> const core::Name&;
+
+		SH_RENDER_API auto GetImpl() const -> IRenderPipelineImpl*;
 	};
 }//namespace

--- a/include/Render/Renderer.h
+++ b/include/Render/Renderer.h
@@ -69,7 +69,7 @@ namespace sh::render
 		virtual void OnCameraAdded(const Camera* camera) {};
 		virtual void OnCameraRemoved(const Camera* camera) {};
 
-		void SetDrawCall(uint32_t drawcall);
+		void SetDrawCallCount(uint32_t drawcall);
 	public:
 		SH_RENDER_API Renderer();
 		SH_RENDER_API virtual ~Renderer();

--- a/include/Render/Texture.h
+++ b/include/Render/Texture.h
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
-
+#include <atomic>
 namespace sh::render
 {
 	class ITextureBuffer;
@@ -36,7 +36,7 @@ namespace sh::render
 		TextureFormat format;
 
 		bool bSRGB = false;
-		bool bDirty;
+		std::atomic<bool> bDirty;
 		bool bFormatDirty = false;
 	protected:
 		const IRenderContext* context;

--- a/include/Render/VulkanImpl/VulkanCommandBuffer.h
+++ b/include/Render/VulkanImpl/VulkanCommandBuffer.h
@@ -10,12 +10,12 @@
 
 namespace sh::render::vk 
 {
+	class VulkanContext;
 	class VulkanCommandBuffer : public core::INonCopyable
 	{
 	private:
+		const VulkanContext& context;
 		VkCommandBuffer buffer;
-
-		VkDevice device;
 		VkCommandPool cmdPool;
 
 		VkPipelineStageFlags waitStage;
@@ -27,7 +27,7 @@ namespace sh::render::vk
 		auto Begin(VkCommandBufferBeginInfo* info = nullptr) -> VkResult;
 		auto End() -> VkResult;
 	public:
-		SH_RENDER_API VulkanCommandBuffer(VkDevice device, VkCommandPool pool, VkQueueFlagBits queueType = VkQueueFlagBits::VK_QUEUE_GRAPHICS_BIT);
+		SH_RENDER_API VulkanCommandBuffer(const VulkanContext& context, VkQueueFlagBits queueType = VkQueueFlagBits::VK_QUEUE_GRAPHICS_BIT);
 		SH_RENDER_API VulkanCommandBuffer(VulkanCommandBuffer&& other) noexcept;
 		SH_RENDER_API ~VulkanCommandBuffer();
 
@@ -42,7 +42,7 @@ namespace sh::render::vk
 
 		SH_RENDER_API auto Build(const std::function<void()>& commands, VkCommandBufferBeginInfo* beginInfo = nullptr) -> VkResult;
 
-		SH_RENDER_API auto Create(const VkCommandBufferAllocateInfo* info = nullptr) -> VkResult;
+		SH_RENDER_API auto Create(VkCommandPool cmdPool, const VkCommandBufferAllocateInfo* info = nullptr) -> VkResult;
 		SH_RENDER_API auto Reset() -> VkResult;
 		SH_RENDER_API void Clear();
 

--- a/include/Render/VulkanImpl/VulkanQueueManager.h
+++ b/include/Render/VulkanImpl/VulkanQueueManager.h
@@ -55,6 +55,6 @@ namespace sh::render::vk
 		SH_RENDER_API auto GetTransferQueue() const -> VkQueue;
 		SH_RENDER_API auto GetSurfaceQueue() const -> VkQueue;
 
-		SH_RENDER_API void SubmitCommand(const VulkanCommandBuffer& cmd, VkFence fence = nullptr);
+		SH_RENDER_API void SubmitCommand(const VulkanCommandBuffer& cmd, VkFence fence = nullptr, bool bBlocking = true);
 	};
 }//namespace

--- a/include/Render/VulkanImpl/VulkanRenderPassManager.h
+++ b/include/Render/VulkanImpl/VulkanRenderPassManager.h
@@ -5,7 +5,7 @@
 
 #include "Core/SContainer.hpp"
 
-#include <mutex>
+#include <shared_mutex>
 namespace sh::render::vk
 {
 	class VulkanContext;
@@ -16,7 +16,7 @@ namespace sh::render::vk
 
 		core::SHashMap<VulkanRenderPass::Config, VulkanRenderPass, 16, VulkanRenderPass::ConfigHasher> renderPasses;
 
-		std::mutex mu;
+		std::shared_mutex mu;
 	private:
 		auto CreateRenderPass(const VulkanRenderPass::Config& config) -> VulkanRenderPass;
 	public:

--- a/include/Render/VulkanImpl/VulkanRenderPipelineImpl.h
+++ b/include/Render/VulkanImpl/VulkanRenderPipelineImpl.h
@@ -19,7 +19,7 @@ namespace sh::render::vk
 	{
 	private:
 		VulkanContext& context;
-		VulkanCommandBuffer* cmd = nullptr;
+		const VulkanCommandBuffer* cmd = nullptr;
 
 		VulkanCameraBuffers* cameraManager = nullptr;
 
@@ -33,6 +33,7 @@ namespace sh::render::vk
 	public:
 		SH_RENDER_API VulkanRenderPipelineImpl(VulkanContext& context);
 
+		SH_RENDER_API void SetCommandBuffer(const VulkanCommandBuffer& cmd);
 		SH_RENDER_API void RecordCommand(const core::Name& lightingPassName, const std::vector<const Camera*>& cameras, const std::vector<RenderGroup>& renderData, uint32_t imgIdx) override;
 
 		/// @brief 렌더링 시 이전에 그려진 프레임 버퍼를 지울지 설정

--- a/include/Render/VulkanImpl/VulkanVertexBuffer.h
+++ b/include/Render/VulkanImpl/VulkanVertexBuffer.h
@@ -36,11 +36,12 @@ namespace sh::render::vk
 		SH_RENDER_API void Create(const Mesh& mesh) override;
 		SH_RENDER_API void Clean() override;
 
-		SH_RENDER_API void Bind() override;
-
 		SH_RENDER_API auto Clone() const -> std::unique_ptr<IVertexBuffer> override;
 
 		SH_RENDER_API static auto GetBindingDescription() -> VkVertexInputBindingDescription;
 		SH_RENDER_API static auto GetAttributeDescriptions() -> std::vector<VkVertexInputAttributeDescription>;
+
+		SH_RENDER_API auto GetVertexBuffer() const -> const VulkanBuffer&;
+		SH_RENDER_API auto GetIndexBuffer() const -> const VulkanBuffer&;
 	};
 }

--- a/src/Core/ThreadPool.cpp
+++ b/src/Core/ThreadPool.cpp
@@ -41,4 +41,12 @@ namespace sh::core
 			);
 		}
 	}
+	SH_CORE_API auto ThreadPool::GetThreads() const -> const std::vector<std::thread>&
+	{
+		return threads;
+	}
+	SH_CORE_API auto ThreadPool::GetThreadNum() const -> uint32_t
+	{
+		return threads.size();
+	}
 }//namepsace

--- a/src/Core/ThreadSyncManager.cpp
+++ b/src/Core/ThreadSyncManager.cpp
@@ -1,4 +1,5 @@
 ﻿#include "ThreadSyncManager.h"
+#include "ThreadPool.h"
 
 #include <algorithm>
 namespace sh::core
@@ -8,7 +9,7 @@ namespace sh::core
 
 	SH_CORE_API auto ThreadSyncManager::GetThreadIndex() -> int
 	{
-		auto it = std::find_if(threads.begin(), threads.end(), [&](const ThreadData& data) {return data.threadPtr && data.threadPtr->GetThreadID() == std::this_thread::get_id(); });
+		auto it = std::find_if(threads.begin(), threads.end(), [&](const ThreadData& data) {return data.threadID == std::this_thread::get_id(); });
 		assert(it != threads.end()); // 현재 코드를 실행중인 스레드는 EngineThread 객체가 존재하지 않는다.
 		if (it == threads.end())
 			return -1;
@@ -18,6 +19,11 @@ namespace sh::core
 	{
 		currentThreadIdx = 0;
 		threads.push_back(ThreadData{ nullptr, std::this_thread::get_id() });
+
+		for (auto& thread : ThreadPool::GetInstance()->GetThreads())
+		{
+			threads.push_back(ThreadData{ nullptr, thread.get_id() });
+		}
 	}
 	SH_CORE_API void ThreadSyncManager::PushSyncable(ISyncable& syncable)
 	{

--- a/src/Editor/EditorOutlinePass.cpp
+++ b/src/Editor/EditorOutlinePass.cpp
@@ -16,17 +16,14 @@ namespace sh::editor
 	}
 	SH_EDITOR_API void EditorOutlinePass::RecordCommand(const std::vector<const render::Camera*>& cameras, uint32_t imgIdx)
 	{
-		std::vector<const render::Camera*> camVec{ &camera->GetNative() };
+		render::Camera copyCamera = camera->GetNative();
 
-		auto beforeMask = camera->GetNative().GetRenderTagMask();
-		auto beforeRenderTexture = camera->GetNative().GetRenderTexture();
-		camera->GetNative().SetRenderTagMask(1);
-		camera->GetNative().SetRenderTexture(output);
+		std::vector<const render::Camera*> camVec{ &copyCamera };
+
+		copyCamera.SetRenderTagMask(1);
+		copyCamera.SetRenderTexture(output);
 
 		render::RenderPipeline::RecordCommand(camVec, imgIdx);
-
-		camera->GetNative().SetRenderTagMask(beforeMask);
-		camera->GetNative().SetRenderTexture(beforeRenderTexture);
 	}
 	SH_EDITOR_API void EditorOutlinePass::SetOutTexture(render::RenderTexture& tex)
 	{

--- a/src/EngineInit.cpp
+++ b/src/EngineInit.cpp
@@ -139,12 +139,11 @@ namespace sh
 		renderer->AddRenderPipeline<sh::render::RenderPipeline>();
 
 		SH_INFO("Thread creation");
+		core::ThreadPool::GetInstance()->Init(std::max(2u, std::thread::hardware_concurrency() / 2));
 		core::ThreadSyncManager::Init();
 		renderThread = game::RenderThread::GetInstance();
 		renderThread->Init(*renderer);
 		core::ThreadSyncManager::AddThread(*renderThread);
-
-		core::ThreadPool::GetInstance()->Init(std::max(2u, std::thread::hardware_concurrency() / 2));
 
 		InitResource();
 

--- a/src/Render/RenderPipeline.cpp
+++ b/src/Render/RenderPipeline.cpp
@@ -114,4 +114,8 @@ namespace sh::render
 	{
 		return passName;
 	}
+	SH_RENDER_API auto RenderPipeline::GetImpl() const -> IRenderPipelineImpl*
+	{
+		return impl.get();
+	}
 }//namespace

--- a/src/Render/Renderer.cpp
+++ b/src/Render/Renderer.cpp
@@ -7,7 +7,7 @@
 #include <cassert>
 namespace sh::render
 {
-	void Renderer::SetDrawCall(uint32_t drawcall)
+	void Renderer::SetDrawCallCount(uint32_t drawcall)
 	{
 		this->drawcall[static_cast<uint32_t>(core::ThreadType::Render)] = drawcall;
 		SyncDirty();

--- a/src/Render/VulkanImpl/VulkanQueueManager.cpp
+++ b/src/Render/VulkanImpl/VulkanQueueManager.cpp
@@ -122,7 +122,7 @@ namespace sh::render::vk
 	{
 		return surfaceQueue;
 	}
-	SH_RENDER_API void VulkanQueueManager::SubmitCommand(const VulkanCommandBuffer& cmd, VkFence fence)
+	SH_RENDER_API void VulkanQueueManager::SubmitCommand(const VulkanCommandBuffer& cmd, VkFence fence, bool bBlocking)
 	{
 		const VkPipelineStageFlags waitStage = cmd.GetWaitStage();
 		const VkCommandBuffer commandBuffer = cmd.GetCommandBuffer();
@@ -152,7 +152,8 @@ namespace sh::render::vk
 		auto result = vkQueueSubmit(queue, 1, &sinfo, fence);
 		assert(result == VkResult::VK_SUCCESS);
 
-		vkQueueWaitIdle(queue);
+		if (bBlocking)
+			vkQueueWaitIdle(queue);
 		spinLock.UnLock();
 	}
 }//namespace

--- a/src/Render/VulkanImpl/VulkanRenderPassManager.cpp
+++ b/src/Render/VulkanImpl/VulkanRenderPassManager.cpp
@@ -16,11 +16,19 @@ namespace sh::render::vk
 
 	SH_RENDER_API auto VulkanRenderPassManager::GetOrCreateRenderPass(const VulkanRenderPass::Config& config) -> VulkanRenderPass&
 	{
-		std::lock_guard<std::mutex> lock{ mu };
-		auto it = renderPasses.find(config);
-		if (it == renderPasses.end())
+		{
+			std::shared_lock<std::shared_mutex> readLock{ mu };
+			auto it = renderPasses.find(config);
+			if (it != renderPasses.end())
+				return it->second;
+		}
+		{
+			std::unique_lock<std::shared_mutex> writeLock{ mu };
+			auto it = renderPasses.find(config);
+			if (it != renderPasses.end())
+				return it->second;
+			
 			return renderPasses.insert_or_assign(config, CreateRenderPass(config)).first->second;
-		else
-			return it->second;
+		}
 	}
 }//namespace

--- a/src/Render/VulkanImpl/VulkanTextureBuffer.cpp
+++ b/src/Render/VulkanImpl/VulkanTextureBuffer.cpp
@@ -143,15 +143,15 @@ namespace sh::render::vk
 
 	SH_RENDER_API void VulkanTextureBuffer::SetData(const void* data)
 	{
-		VulkanBuffer stagingBuffer{ *this->context };
+		VulkanBuffer stagingBuffer{ *context };
 		stagingBuffer.Create(size,
 			VkBufferUsageFlagBits::VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
 			VkSharingMode::VK_SHARING_MODE_EXCLUSIVE,
 			VkMemoryPropertyFlagBits::VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VkMemoryPropertyFlagBits::VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 		stagingBuffer.SetData(data);
 
-		cmd = std::make_unique<VulkanCommandBuffer>(this->context->GetDevice(), this->context->GetCommandPool(core::ThreadType::Game), VkQueueFlagBits::VK_QUEUE_GRAPHICS_BIT);
-		cmd->Create();
+		cmd = std::make_unique<VulkanCommandBuffer>(*context, VkQueueFlagBits::VK_QUEUE_GRAPHICS_BIT);
+		cmd->Create(context->GetCommandPool(core::ThreadType::Game));
 
 		cmd->Build([&]
 			{


### PR DESCRIPTION
![병렬전](https://github.com/user-attachments/assets/553af94b-f248-47a9-af37-7aa2ac80cd24)
병렬 전 40,000드로우 콜에서 렌더 스레드 작업에 걸린 시간 평균 13,200 마이크로초

![병렬후](https://github.com/user-attachments/assets/fa7fa6ab-b2d4-4b22-a4a1-79610ff0c9b5)
병렬 후 40,000드로우 콜에서 렌더 스레드 작업에 걸린 시간 평균 11,500 마이크로초