### PR TITLE
feat(World): Improve world loop performance via better cache locality

### DIFF
--- a/include/Game/GameObject.h
+++ b/include/Game/GameObject.h
@@ -19,12 +19,19 @@ namespace sh::game
 	{
 		SCLASS(GameObject)
 	public:
-		SH_GAME_API GameObject(World& world, const std::string& name);
-		SH_GAME_API GameObject(const GameObject& other);
+		struct CreateKey
+		{
+		private:
+			friend World;
+			CreateKey() = default;
+		};
+	public:
+		SH_GAME_API GameObject(World& world, const std::string& name, CreateKey key);
 		SH_GAME_API ~GameObject();
 
 		SH_GAME_API auto operator=(const GameObject& other) -> GameObject&;
 
+		SH_GAME_API void Destroy() override;
 		SH_GAME_API void OnDestroy() override;
 		SH_GAME_API void Awake() override;
 		SH_GAME_API void Start() override;
@@ -57,6 +64,8 @@ namespace sh::game
 		SH_GAME_API auto Serialize() const -> core::Json override;
 		SH_GAME_API void Deserialize(const core::Json& json) override;
 		SH_GAME_API void OnPropertyChanged(const core::reflection::Property& prop) override;
+
+		SH_GAME_API auto IsStatic() const -> bool { return bStatic; }
 	public:
 		/// @brief 새 컴포넌트를 추가하는 함수
 		/// @tparam T 컴포넌트 타입
@@ -135,5 +144,7 @@ namespace sh::game
 		bool bEnable;
 		bool bParentEnable = true;
 		bool bRequestSortComponent = false;
+		PROPERTY(bStatic)
+		bool bStatic = false;
 	};
 }//namespace

--- a/include/Game/World.h
+++ b/include/Game/World.h
@@ -72,7 +72,7 @@ namespace sh::game
 		/// @param name 이름
 		/// @return 못 찾을 시 nullptr, 찾을 시 게임 오브젝트 포인터
 		SH_GAME_API auto GetGameObject(std::string_view name) const -> GameObject*;
-		SH_GAME_API auto GetGameObjects() const -> const core::SHashSet<GameObject*>&;
+		SH_GAME_API auto GetGameObjects() const -> const std::vector<GameObject*>& { return objs; }
 		SH_GAME_API auto GetGameObjectPool() -> core::memory::MemoryPool<GameObject>&;
 		/// @brief 게임 오브젝트가 할당된 메모리를 반환 큐에 넣는 함수.
 		/// @param ptr 오브젝트 포인터
@@ -141,7 +141,8 @@ namespace sh::game
 		const ComponentModule& componentModule;
 	protected:
 		core::EventBus eventBus;
-		core::SHashSet<GameObject*> objs;
+		std::unordered_map<GameObject*, std::size_t> objIdx;
+		std::vector<GameObject*> objs;
 		core::SHashSet<Camera*> cameras;
 
 		std::unique_ptr<render::ScriptableRenderer> customRenderer;

--- a/src/Game/GameObject.cpp
+++ b/src/Game/GameObject.cpp
@@ -8,38 +8,12 @@
 
 namespace sh::game
 {
-	SH_GAME_API GameObject::GameObject(World& world, const std::string& name) :
+	SH_GAME_API GameObject::GameObject(World& world, const std::string& name, CreateKey key) :
 		world(world),
 		bEnable(true), activeSelf(bEnable)
 	{
 		transform = AddComponent<Transform>();
 		SetName(name);
-	}
-
-	GameObject::GameObject(const GameObject& other) :
-		SObject(other),
-		world(other.world), activeSelf(bEnable),
-		bEnable(other.bEnable), hideInspector(other.hideInspector), bNotSave(other.bNotSave)
-	{
-		transform = AddComponent<Transform>();
-		*transform = *other.transform;
-
-		for (int i = 1; i < other.components.size(); ++i)
-		{
-			Component* component = other.components[i];
-			if (!core::IsValid(component))
-				continue;
-
-			IComponentType* componentType = ComponentModule::GetInstance()->GetComponent(component->GetName().ToString());
-			if (componentType == nullptr)
-			{
-				SH_ERROR_FORMAT("Not found component: {}", component->GetName().ToString());
-				continue;
-			}
-			Component* copyComponent = componentType->Clone(*this, *component);
-			if (copyComponent)
-				AddComponent(copyComponent);
-		}
 	}
 
 	SH_GAME_API GameObject::~GameObject()
@@ -116,6 +90,11 @@ namespace sh::game
 				if (world.IsPlaying() || component->canPlayInEditor)
 					component->OnDisable();
 		}
+	}
+	SH_GAME_API void GameObject::Destroy()
+	{
+		Super::Destroy();
+		world.DestroyGameObject(*this);
 	}
 	SH_GAME_API void GameObject::OnDestroy()
 	{


### PR DESCRIPTION
문제: Release빌드에서 5만개의 빈 오브젝트가 있는 상황에서 프레임 드랍</br>
<img width="442" height="404" alt="스크린샷 2026-01-07 144840" src="https://github.com/user-attachments/assets/c3a67063-ef1d-4eb3-b02c-3a965d90cba7" /></br>
msvc 프로파일러에서 확인한 결과 월드 루프 내 오브젝트 순회에서 지연 발생 확인</br>

<img width="990" height="50" alt="image" src="https://github.com/user-attachments/assets/3621afe7-6302-4d69-9ae4-8cf326ab250c" /></br>
캐시 미스로 인한 병목으로 판단 -> 순회 속도를 높이기 위해 오브젝트 목록을 SHashSet(unordered_set)으로 관리하던 것을 벡터와 맵을 통해 구조 변경</br>
(오브젝트들은 배열 형태의 메모리 풀에 존재하므로 포인터여도 지역성 문제는 없음)</br>

<img width="1122" height="470" alt="image" src="https://github.com/user-attachments/assets/966dd9a1-fc55-452c-afd3-7dc0cb19d1af" /></br>
hash set의 검색 기능은 오브젝트를 제거 할 때만 사용됐으므로 구조 변경 가능</br>

<img width="316" height="95" alt="스크린샷 2026-01-07 144548" src="https://github.com/user-attachments/assets/d579eba9-638f-43b9-b00a-2c5098e64b6a" /></br>
최적화 전: 5만개의 빈 오브젝트 평균24ms</br>
<img width="315" height="98" alt="스크린샷 2026-01-07 143748" src="https://github.com/user-attachments/assets/945561a9-3c88-4b1d-a226-dda14333a639" /></br>
최적화 후: 5만개의 빈 오브젝트 평균10ms</br>

결과: 약 140%의 성능 향상

